### PR TITLE
Defend against missing key in form data

### DIFF
--- a/wagtailautocomplete/widgets.py
+++ b/wagtailautocomplete/widgets.py
@@ -30,7 +30,11 @@ class Autocomplete(Widget):
             return json.dumps(render_page(model.objects.get(pk=value)))
 
     def value_from_datadict(self, data, files, name):
-        value = json.loads(data.get(name))
+        value_json = data.get(name)
+        if not value_json:
+            return None
+
+        value = json.loads(value_json)
         if not value:
             return None
 


### PR DESCRIPTION
The frontend JS for this form isn't always ready in time for a form submission. It is possible to submit a form from the Wagtail admin with an autocomplete field missing. The result is a TypeErrror:

```
File "/usr/local/lib/python3.6/site-packages/django/forms/forms.py", line 396, in _clean_fields

    value = field.widget.value_from_datadict(self.data, self.files, self.add_prefix(name))

File "/usr/local/lib/python3.6/site-packages/wagtailautocomplete/widgets.py", line 33, in value_from_datadict

    value = json.loads(data.get(name))

File "/usr/local/lib/python3.6/json/__init__.py", line 348, in loads

    'not {!r}'.format(s.__class__.__name__))

TypeError: the JSON object must be str, bytes or bytearray, not 'NoneType'
```

This change makes the code a little uglier but is necessary to stop the widget from exploding in some edge cases

This happens to me because I have some JS that submits the Wagtail editor's `<form>` element on page load. This is a niche use-case, but in general I think it should be harder to break this widget.