### PR TITLE
Increase the number of suggestion results returned

### DIFF
--- a/wagtailautocomplete/views.py
+++ b/wagtailautocomplete/views.py
@@ -54,6 +54,11 @@ def search(request):
     except Exception:
         return HttpResponseBadRequest
 
+    try:
+        limit = int(request.GET.get('limit', 100))
+    except ValueError:
+        return HttpResponseBadRequest
+
     field_name = getattr(model, 'autocomplete_search_field', 'title')
     filter_kwargs = dict()
     filter_kwargs[field_name + '__icontains'] = search_query
@@ -70,7 +75,7 @@ def search(request):
     except Exception:
         pass
 
-    results = map(render_page, queryset[:20])
+    results = map(render_page, queryset[:limit])
     return JsonResponse(dict(items=list(results)))
 
 


### PR DESCRIPTION
Having a maximum number of 20 suggestions being returned can be
restrictive for some uses, such as browsing possible entries when one
is less aware of the potential result-space.  This change makes the
default number of suggestions returned more extensive.  It also allows
a `limit` parameter to be sent with the GET request to override the
default value of 100 if that amount is too large or too small.