### PR TITLE
Rename `page_type` to `target_model`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Python
 *.pyc
 __pycache__
+venv/
 
 # Node
 node_modules

--- a/docs/basic_usage.rst
+++ b/docs/basic_usage.rst
@@ -35,7 +35,7 @@ Instead we can use :py:class:`AutocompletePanel`.
 .. code-block:: python
 
     content_panels = Page.content_panels + [
-        AutocompletePanel('author', page_type='app_label.AuthorPage'),
+        AutocompletePanel('author', target_model='app_label.AuthorPage'),
     ]
 
 .. image:: /_static/autocomplete-fk-demo.gif
@@ -46,10 +46,10 @@ AutocompletePanel
 
 .. module:: wagtailautocomplete.edit_handlers
 
-.. class:: AutocompletePanel(field_name, page_type='wagtailcore.Page', is_single=True)
+.. class:: AutocompletePanel(field_name, target_model='wagtailcore.Page', is_single=True)
 
     ``AutocompletePanel`` takes one required argument, the field name.
-    Optionally, you can pass a single ``page_type`` which will limit the
+    Optionally, you can pass a single ``target_model`` which will limit the
     objects an editor can select to that model — this argument should be
     passed in ``app_label.ModelName`` syntax.
 
@@ -61,7 +61,7 @@ AutocompletePanel
 
     .. note::
         Unlike :class:`~wagtail:wagtail.wagtailadmin.edit_handlers.PageChooserPanel`,
-        ``AutocompletePanel`` does not support receiving ``page_type`` as a list.
+        ``AutocompletePanel`` does not support receiving ``target_model`` as a list.
 
     .. note::
         ``AutocompletePanel`` does not support receiving the ``can_choose_root``
@@ -96,7 +96,7 @@ explicitly to enable this behavior. For example:
         )
 
         content_panels = Page.content_panels + [
-            AutocompletePanel('books', page_type='home.Book', is_single=False)
+            AutocompletePanel('books', target_model='home.Book', is_single=False)
         ]
 
 .. image:: /_static/autocomplete-m2m-demo.gif

--- a/docs/using_other_models.rst
+++ b/docs/using_other_models.rst
@@ -56,10 +56,3 @@ usage with
     panels = [
         AutocompletePanel('external_link', target_model='app_label.Link'),
     ]
-
-.. note::
-    :doc:`wagtail-autocomplete <index>` does not offer two separate edit
-    handlers like Wagtail does for Page and Snippet. As such,
-    ``AutocompletePanel`` does not support the ``snippet_type`` kwarg that
-    :class:`~wagtail:wagtail.wagtailsnippets.edit_handlers.SnippetChooserPanel`
-    does. Instead, ``target_model`` should be used.

--- a/docs/using_other_models.rst
+++ b/docs/using_other_models.rst
@@ -54,7 +54,7 @@ usage with
 .. code-block:: python
 
     panels = [
-        AutocompletePanel('external_link', page_type='app_label.Link'),
+        AutocompletePanel('external_link', target_model='app_label.Link'),
     ]
 
 .. note::
@@ -62,4 +62,4 @@ usage with
     handlers like Wagtail does for Page and Snippet. As such,
     ``AutocompletePanel`` does not support the ``snippet_type`` kwarg that
     :class:`~wagtail:wagtail.wagtailsnippets.edit_handlers.SnippetChooserPanel`
-    does. Instead, ``page_type`` should be used.
+    does. Instead, ``target_model`` should be used.

--- a/wagtailautocomplete/edit_handlers.py
+++ b/wagtailautocomplete/edit_handlers.py
@@ -28,7 +28,7 @@ if VERSION < (2, 0):
             self.field_name = field_name
             self.target_model = target_model
             self.is_single = is_single
-
+            # For compatability with old 'page_type' argument
             if 'page_type' in kwargs:
                 warnings.warn(
                     'page_type argument has been replaced with target_model',
@@ -58,6 +58,7 @@ else:
             # compatibility with wagtailadmin.edit_handlers.PageChooserPanel.
             self.target_model = target_model
             self.is_single = is_single
+            # For compatability with old 'page_type' argument
             if 'page_type' in kwargs:
                 warnings.warn(
                     'page_type argument has been replaced with target_model',

--- a/wagtailautocomplete/edit_handlers.py
+++ b/wagtailautocomplete/edit_handlers.py
@@ -1,16 +1,17 @@
-from django.apps import apps
+import warnings
 
+from django.apps import apps
 from wagtail import VERSION
 
 from .widgets import Autocomplete
 
 
-def _can_create(page_type):
+def _can_create(model_string):
     """Returns True if the given model has implemented the autocomplete_create
     method to allow new instances to be creates from a single string value.
     """
     return callable(getattr(
-        apps.get_model(page_type),
+        apps.get_model(model_string),
         'autocomplete_create',
         None,
     ))
@@ -21,22 +22,29 @@ if VERSION < (2, 0):
     from wagtail.wagtailadmin.edit_handlers import BaseFieldPanel
 
     class AutocompletePanel:
-        def __init__(self, field_name, page_type='wagtailcore.Page', is_single=True):
+        def __init__(self, field_name, target_model='wagtailcore.Page', is_single=True, **kwargs):
             # is_single defaults to True in order to have easy drop-in
             # compatibility with wagtailadmin.edit_handlers.PageChooserPanel.
             self.field_name = field_name
-            self.page_type = page_type
+            self.target_model = target_model
             self.is_single = is_single
 
+            if 'page_type' in kwargs:
+                warnings.warn(
+                    'page_type argument has been replaced with target_model',
+                    DeprecationWarning
+                )
+                self.target_model = kwargs['page_type']
+
         def bind_to_model(self, model):
-            can_create = _can_create(self.page_type)
+            can_create = _can_create(self.target_model)
             base = dict(
                 model=model,
                 field_name=self.field_name,
                 widget=type(
                     '_Autocomplete',
                     (Autocomplete,),
-                    dict(page_type=self.page_type, can_create=can_create, is_single=self.is_single),
+                    dict(target_model=self.target_model, can_create=can_create, is_single=self.is_single),
                 ),
             )
             return type('_AutocompleteFieldPanel', (BaseFieldPanel,), base)
@@ -45,24 +53,31 @@ else:
     from wagtail.admin.edit_handlers import FieldPanel
 
     class AutocompletePanel(FieldPanel):
-        def __init__(self, field_name, page_type='wagtailcore.Page', is_single=True, **kwargs):
+        def __init__(self, field_name, target_model='wagtailcore.Page', is_single=True, **kwargs):
             super().__init__(field_name, **kwargs)
             # is_single defaults to True in order to have easy drop-in
             # compatibility with wagtailadmin.edit_handlers.PageChooserPanel.
-            self.page_type = page_type
+            self.target_model = target_model
             self.is_single = is_single
+
+            if 'page_type' in kwargs:
+                warnings.warn(
+                    'page_type argument has been replaced with target_model',
+                    DeprecationWarning
+                )
+                self.target_model = kwargs['page_type']
 
         def clone(self):
             return self.__class__(
                 field_name=self.field_name,
-                page_type=self.page_type,
+                target_model=self.target_model,
                 is_single=self.is_single
             )
 
         def on_model_bound(self):
-            can_create = _can_create(self.page_type)
+            can_create = _can_create(self.target_model)
             self.widget = type(
                 '_Autocomplete',
                 (Autocomplete,),
-                dict(page_type=self.page_type, can_create=can_create, is_single=self.is_single),
+                dict(target_model=self.target_model, can_create=can_create, is_single=self.is_single),
             )

--- a/wagtailautocomplete/edit_handlers.py
+++ b/wagtailautocomplete/edit_handlers.py
@@ -54,18 +54,18 @@ else:
 
     class AutocompletePanel(FieldPanel):
         def __init__(self, field_name, target_model='wagtailcore.Page', is_single=True, **kwargs):
-            super().__init__(field_name, **kwargs)
             # is_single defaults to True in order to have easy drop-in
             # compatibility with wagtailadmin.edit_handlers.PageChooserPanel.
             self.target_model = target_model
             self.is_single = is_single
-
             if 'page_type' in kwargs:
                 warnings.warn(
                     'page_type argument has been replaced with target_model',
                     DeprecationWarning
                 )
                 self.target_model = kwargs['page_type']
+                del kwargs['page_type']
+            super().__init__(field_name, **kwargs)
 
         def clone(self):
             return self.__class__(

--- a/wagtailautocomplete/templates/wagtailautocomplete/autocomplete.html
+++ b/wagtailautocomplete/templates/wagtailautocomplete/autocomplete.html
@@ -1,7 +1,7 @@
 <span
     data-autocomplete-input-name="{{ widget.name }}"
     data-autocomplete-input-value="{{ widget.value }}"
-    data-autocomplete-input-type="{{ widget.page_type }}"
+    data-autocomplete-input-type="{{ widget.target_model }}"
     data-autocomplete-input-id="{{ widget.attrs.id }}"
     {% if widget.can_create %}
         data-autocomplete-input-can-create

--- a/wagtailautocomplete/tests/testapp/models/page_to_page.py
+++ b/wagtailautocomplete/tests/testapp/models/page_to_page.py
@@ -1,5 +1,6 @@
 from django.db import models
 from modelcluster.fields import ParentalManyToManyField
+
 from wagtailautocomplete.edit_handlers import AutocompletePanel
 
 try:
@@ -20,7 +21,7 @@ class SingleAutocompletePage(Page):
     )
 
     content_panels = Page.content_panels + [
-        AutocompletePanel('target', page_type='testapp.TargetPage'),
+        AutocompletePanel('target', target_model='testapp.TargetPage'),
     ]
 
 

--- a/wagtailautocomplete/views.py
+++ b/wagtailautocomplete/views.py
@@ -21,9 +21,9 @@ def objects(request):
     ids_param = request.GET.get('ids')
     if not ids_param:
         return HttpResponseBadRequest
-    page_type = request.GET.get('type', 'wagtailcore.Page')
+    target_model = request.GET.get('type', 'wagtailcore.Page')
     try:
-        model = apps.get_model(page_type)
+        model = apps.get_model(target_model)
     except Exception:
         return HttpResponseBadRequest
 
@@ -48,9 +48,9 @@ def objects(request):
 @require_GET
 def search(request):
     search_query = request.GET.get('query', '')
-    page_type = request.GET.get('type', 'wagtailcore.Page')
+    target_model = request.GET.get('type', 'wagtailcore.Page')
     try:
-        model = apps.get_model(page_type)
+        model = apps.get_model(target_model)
     except Exception:
         return HttpResponseBadRequest
 
@@ -85,9 +85,9 @@ def create(request, *args, **kwargs):
     if not value:
         return HttpResponseBadRequest
 
-    page_type = request.POST.get('type', 'wagtailcore.Page')
+    target_model = request.POST.get('type', 'wagtailcore.Page')
     try:
-        model = apps.get_model(page_type)
+        model = apps.get_model(target_model)
     except Exception:
         return HttpResponseBadRequest
 

--- a/wagtailautocomplete/widgets.py
+++ b/wagtailautocomplete/widgets.py
@@ -11,7 +11,7 @@ class Autocomplete(Widget):
 
     def get_context(self, *args, **kwargs):
         context = super(Autocomplete, self).get_context(*args, **kwargs)
-        context['widget']['page_type'] = self.page_type
+        context['widget']['target_model'] = self.target_model
         context['widget']['can_create'] = self.can_create
         context['widget']['is_single'] = self.is_single
         return context
@@ -20,7 +20,7 @@ class Autocomplete(Widget):
         if not value:
             return 'null'
 
-        model = apps.get_model(self.page_type)
+        model = apps.get_model(self.target_model)
         if type(value) == list:
             return json.dumps([
                 render_page(page)


### PR DESCRIPTION
Fix for #16  

Shouldn't break backwards compatibility with users still using the old arguments.