### PR TITLE
Fix documentation for installing test suite

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -74,7 +74,7 @@ This project uses ``pytest`` and ``tox`` to run its test suite. To install ``pyt
 .. code-block:: sh
 
     cd /path/to/wagtail-autocomplete
-    pip install -e .[tests]
+    pip install -e .[test]
     pytest
 
 To run the test suite against all dependency permutations, ensure that you have all the necessary Python interpreters installed and run:


### PR DESCRIPTION
The test extras for this package is named `test`, not `tests`.  Just getting the docs in sync with the setup.py file :)