### PR TITLE
Indexed searching

### DIFF
--- a/docs/customization.rst
+++ b/docs/customization.rst
@@ -27,7 +27,11 @@ You can enable this type of behavior by defining an ``autocomplete_create`` clas
 Custom Search Field
 ===================
 
-By default, the autocomplete widget will match input against the ``title`` field on your model. If you're using a model that doesn't have a ``title`` attribute, or you just want to search using a different field, you can customize which field it matches against by defining an ``autocomplete_search_field`` property on your model:
+If your model is indexed using the native Wagtail `indexing methods <https://docs.wagtail.io/en/latest/topics/search/indexing.html>`_, then the configured backend will be used to search accross all indexed fields.
+You can narrow the scope by setting the ``autocomplete_search_field`` on the model like in the example to only search one field.
+
+If your model is not indexed then the native Django ORM is used to match input against the ``title`` field on your model.
+If you're using a model that doesn't have a ``title`` attribute, or you just want to search using a different field, you can customize which field it matches against by defining an ``autocomplete_search_field`` property on your model:
 
 .. code-block:: python
 

--- a/wagtailautocomplete/views.py
+++ b/wagtailautocomplete/views.py
@@ -8,8 +8,14 @@ from django.contrib.contenttypes.models import ContentType
 from django.http import (HttpResponseBadRequest, HttpResponseForbidden,
                          JsonResponse)
 from django.views.decorators.http import require_GET, require_POST
-from wagtail.search.backends import get_search_backend
-from wagtail.search.index import Indexed
+from wagtail import VERSION
+
+if VERSION > (2, 0):
+    from wagtail.search.backends import get_search_backend
+    from wagtail.search.index import Indexed
+else:
+    from wagtail.wagtailsearch.backends import get_search_backend
+    from wagtail.wagtailsearch.index import Indexed
 
 
 def render_page(page):


### PR DESCRIPTION
I ran into a problem where I wanted to search across multiple fields which isn't possible at the moment. I thought of extending the `autocomplete_search_field` so it could return multiple fields but that could be a breaking change. (It probably should do that eventually anyway)

Instead since my models were indexed using the Wagtail indexing methods I opted to allow the native Wagtail searching for indexed models. This is a drop in replacement and doesn't require any changes for people already using wagtail-autocomplete