### PR TITLE
Remove is_single, make target_model optional

### DIFF
--- a/docs/basic_usage.rst
+++ b/docs/basic_usage.rst
@@ -35,7 +35,7 @@ Instead we can use :py:class:`AutocompletePanel`.
 .. code-block:: python
 
     content_panels = Page.content_panels + [
-        AutocompletePanel('author', target_model='app_label.AuthorPage'),
+        AutocompletePanel('author'),
     ]
 
 .. image:: /_static/autocomplete-fk-demo.gif
@@ -46,18 +46,12 @@ AutocompletePanel
 
 .. module:: wagtailautocomplete.edit_handlers
 
-.. class:: AutocompletePanel(field_name, target_model='wagtailcore.Page', is_single=True)
+.. class:: AutocompletePanel(field_name, target_model='wagtailcore.Page')
 
     ``AutocompletePanel`` takes one required argument, the field name.
     Optionally, you can pass a single ``target_model`` which will limit the
-    objects an editor can select to that model — this argument should be
-    passed in ``app_label.ModelName`` syntax.
-
-    ``is_single`` determines whether the editor can select one object (with
-    the default value of ``True``) or multiple objects (with ``False``). The
-    default value is fine for drop-in
-    :class:`~wagtail:wagtail.wagtailadmin.edit_handlers.PageChooserPanel`
-    replacement.
+    objects an editor can select to that model — this argument can be a refrence
+    to a model class or a model string in ``app_label.ModelName`` syntax.
 
     .. note::
         Unlike :class:`~wagtail:wagtail.wagtailadmin.edit_handlers.PageChooserPanel`,
@@ -72,8 +66,7 @@ Multiple Selection With Clusterable Models
 ==========================================
 
 ``AutocompletePanel`` can also be used with a ``ParentalManyToManyField`` to
-provide a multiple selection widget. You must pass ``is_single=False``
-explicitly to enable this behavior. For example:
+provide a multiple selection widget. For example:
 
 .. code-block:: python
 
@@ -96,7 +89,7 @@ explicitly to enable this behavior. For example:
         )
 
         content_panels = Page.content_panels + [
-            AutocompletePanel('books', target_model='home.Book', is_single=False)
+            AutocompletePanel('books', target_model=Book)
         ]
 
 .. image:: /_static/autocomplete-m2m-demo.gif

--- a/docs/using_other_models.rst
+++ b/docs/using_other_models.rst
@@ -54,5 +54,5 @@ usage with
 .. code-block:: python
 
     panels = [
-        AutocompletePanel('external_link', target_model='app_label.Link'),
+        AutocompletePanel('external_link'),
     ]

--- a/wagtailautocomplete/edit_handlers.py
+++ b/wagtailautocomplete/edit_handlers.py
@@ -33,6 +33,8 @@ if VERSION < (2, 0):
                     DeprecationWarning
                 )
                 self.target_model = kwargs['page_type']
+            if 'is_single' in kwargs:
+                warnings.warn('is_single argument is no longer used', DeprecationWarning)
 
         def bind_to_model(self, model):
             if not self.target_model:
@@ -69,6 +71,8 @@ else:
                     DeprecationWarning
                 )
                 target_model = kwargs.pop('page_type', None)
+            if 'is_single' in kwargs:
+                warnings.warn('is_single argument is no longer used', DeprecationWarning)
             self.target_model_kwarg = target_model
 
             kwargs.pop('is_single', None)  # Deprecated kwarg

--- a/wagtailautocomplete/edit_handlers.py
+++ b/wagtailautocomplete/edit_handlers.py
@@ -77,7 +77,7 @@ else:
         def clone(self):
             return self.__class__(
                 field_name=self.field_name,
-                target_model=self.target_model,
+                target_model=self.target_model_kwarg,
             )
 
         @property

--- a/wagtailautocomplete/edit_handlers.py
+++ b/wagtailautocomplete/edit_handlers.py
@@ -19,29 +19,23 @@ if VERSION < (2, 0):
     # Wagtail 1.x
     from wagtail.wagtailadmin.edit_handlers import BaseFieldPanel
 
-    class AutocompletePanel(BaseFieldPanel):
+    class AutocompletePanel:
         def __init__(self, field_name, **kwargs):
             self.field_name = field_name
-            print(self.bound_field)
-
-        @property
-        def is_single(self):
-            # Should cover all manny-to-many relationships
-            return not issubclass(self.bound_field, ManyToManyField)
-
-        @property
-        def target_model(self):
-            return self.bound_field.remote_field.model
 
         def bind_to_model(self, model):
-            can_create = _can_create(self.target_model)
+            target_model = model._meta.get_field(self.field_name).remote_field.model
+            is_single = not issubclass(model._meta.get_field(self.field_name).__class__,
+                                       ManyToManyField)
+            can_create = _can_create(target_model)
+
             base = dict(
                 model=model,
                 field_name=self.field_name,
                 widget=type(
                     '_Autocomplete',
                     (Autocomplete,),
-                    dict(target_model=self.target_model, can_create=can_create, is_single=self.is_single),
+                    dict(target_model=target_model, can_create=can_create, is_single=is_single),
                 ),
             )
             return type('_AutocompleteFieldPanel', (BaseFieldPanel,), base)
@@ -50,7 +44,7 @@ else:
     from wagtail.admin.edit_handlers import FieldPanel
 
     class AutocompletePanel(FieldPanel):
-        def __init__(self, field_name, *args, **kwargs):
+        def __init__(self, field_name, **kwargs):
             super().__init__(field_name)
 
         @property

--- a/wagtailautocomplete/widgets.py
+++ b/wagtailautocomplete/widgets.py
@@ -1,6 +1,5 @@
 import json
 
-from django.apps import apps
 from django.forms import Widget
 from wagtail import VERSION
 
@@ -17,7 +16,7 @@ class Autocomplete(Widget):
 
     def get_context(self, *args, **kwargs):
         context = super(Autocomplete, self).get_context(*args, **kwargs)
-        context['widget']['target_model'] = self.target_model
+        context['widget']['target_model'] = self.target_model._meta.label
         context['widget']['can_create'] = self.can_create
         context['widget']['is_single'] = self.is_single
         return context
@@ -25,15 +24,13 @@ class Autocomplete(Widget):
     def format_value(self, value):
         if not value:
             return 'null'
-
-        model = apps.get_model(self.target_model)
         if type(value) == list:
             return json.dumps([
                 render_page(page)
-                for page in model.objects.filter(pk__in=value)
+                for page in self.target_model.objects.filter(pk__in=value)
             ])
         else:
-            return json.dumps(render_page(model.objects.get(pk=value)))
+            return json.dumps(render_page(self.target_model.objects.get(pk=value)))
 
     def value_from_datadict(self, data, files, name):
         value = json.loads(data.get(name))


### PR DESCRIPTION
Fixes #22 Should simplify most cases :smile: 

`target_model` can now take a reference to a model as well instead of a model string.

I think there's an argument to be made to ditch `target_model` all together. I can't picture a use case when you wouldn't just point the FK to the same model, even in the case of subclasses. Anyway, this should be backwards compatible with current users.

The tests are passing but I didn't have a pre 2.0 install handy to test on, might be worth checking its all good. 