### PR TITLE
Improves docs to specify when to use content_panels and when to use panels

### DIFF
--- a/docs/basic_usage.rst
+++ b/docs/basic_usage.rst
@@ -68,6 +68,11 @@ Multiple Selection With Clusterable Models
 ``AutocompletePanel`` can also be used with a ``ParentalManyToManyField`` to
 provide a multiple selection widget. For example:
 
+.. note::
+   Use ``content_panels`` when the model is inherited from ``Page``. If it is
+   inherited from ``models.Model`` or ``ClusterableModel``, then we need to
+   use ``panels`` instead of ``content_panels``.
+
 .. code-block:: python
 
     from django.db import models


### PR DESCRIPTION
Improves docs to specify to use content_panels when it is of type `Page` and panels when it is Models or ClusterableModel.