### PR TITLE
Adds Django 3.0 support

### DIFF
--- a/wagtailautocomplete/wagtail_hooks.py
+++ b/wagtailautocomplete/wagtail_hooks.py
@@ -1,7 +1,4 @@
-try:
-    from django.contrib.staticfiles.templatetags.staticfiles import static
-except ModuleNotFoundError:
-    from django.templatetags.static import static
+from django.templatetags.static import static
 
 from django.utils.html import format_html
 

--- a/wagtailautocomplete/wagtail_hooks.py
+++ b/wagtailautocomplete/wagtail_hooks.py
@@ -2,7 +2,7 @@ try:
     from django.contrib.staticfiles.templatetags.staticfiles import static
 except ModuleNotFoundError:
     from django.templatetags.static import static
-    
+
 from django.utils.html import format_html
 
 from wagtail.core import hooks

--- a/wagtailautocomplete/wagtail_hooks.py
+++ b/wagtailautocomplete/wagtail_hooks.py
@@ -1,5 +1,4 @@
 from django.templatetags.static import static
-
 from django.utils.html import format_html
 
 from wagtail.core import hooks

--- a/wagtailautocomplete/wagtail_hooks.py
+++ b/wagtailautocomplete/wagtail_hooks.py
@@ -1,4 +1,8 @@
-from django.contrib.staticfiles.templatetags.staticfiles import static
+try:
+    from django.contrib.staticfiles.templatetags.staticfiles import static
+except ModuleNotFoundError:
+    from django.templatetags.static import static
+    
 from django.utils.html import format_html
 
 from wagtail.core import hooks


### PR DESCRIPTION
Hi, this PR adds Django 3.0 support. `from django.contrib.staticfiles.templatetags.staticfiles import static` has changed it location in Django 3.0 to `from django.templatetags.static import static`. This PR supports both Django 2.x and 3.x

Resolves #65