### PR TITLE
Update tox.ini and tested versions

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -9,7 +9,7 @@ We accept both issue reports and code contributions through our `GitHub reposito
 Code Style
 ----------
 
-This repo follows `Wagtail's guidelines <http://docs.wagtail.io/en/v1.11.1/contributing/index.html>`_.
+This repo follows `Wagtail's guidelines <https://docs.wagtail.io/en/stable/contributing/index.html>`_.
 Clone ``wagtail/wagtail`` in a separate folder and run linters with their configuration.
 
 .. code-block:: sh

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -5,7 +5,7 @@ Getting Started
 Requirements
 ============
 
-Wagtail Autocomplete requires Wagtail version 1.11 or newer.
+Wagtail Autocomplete requires Wagtail version 2.3 or newer.
 
 Installation
 ============

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,7 @@
+[flake8]
+ignore = E501,E402
+
+[tool:pytest]
+testpaths = wagtailautocomplete docs
+DJANGO_SETTINGS_MODULE = wagtailautocomplete.tests.settings
+django_find_project = false

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     license='BSD-3-Clause',
 
     install_requires=[
-        'wagtail>=1.11',
+        'wagtail>=2.3',
     ],
 
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,9 @@ setup(
             'tox',
             'pytest>=3.5',
             'pytest-django>=3.2',
-            'beautifulsoup4>=4.6.0',
+            # FIXME: the maximum version is needed until
+            # https://github.com/wagtail/wagtail/pull/5817
+            'beautifulsoup4>=4.6.0,<4.6.1',
             'html5lib>=0.999999999',
             'pytest-pythonpath>=0.7.2',
         ],

--- a/tox.ini
+++ b/tox.ini
@@ -15,14 +15,6 @@ deps =
   wagtail26: wagtail>=2.6,<2.7
 
 [testenv:flake8]
-basepython=python3.6
-deps=flake8>3.7
-commands=flake8 wagtailautocomplete
-
-[flake8]
-ignore: E501,E402
-
-[pytest]
-testpaths = wagtailautocomplete docs
-DJANGO_SETTINGS_MODULE = wagtailautocomplete.tests.settings
-django_find_project = false
+basepython = python3.6
+deps = flake8>3.7
+commands = flake8 wagtailautocomplete

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,14 @@
 [tox]
+skipsdist = True
+usedevelop = True
 envlist =
   py{34,35,36}-django111-wagtail23
   py{35,36}-django21-wagtail23
   py{35,36,37}-django{21,22}-wagtail27
 
 [testenv]
-commands = pytest
-extras = test
+install_command = pip install -e ".[test]" -U {opts} {packages}
+commands = py.test
 deps =
   django111: django>=1.11,<1.12
   django21: django>=2.1,<2.2

--- a/tox.ini
+++ b/tox.ini
@@ -2,19 +2,25 @@
 skipsdist = True
 usedevelop = True
 envlist =
-  py{34,35,36}-django111-wagtail23
-  py{35,36}-django21-wagtail23
-  py{35,36,37}-django{21,22}-wagtail27
+    py{35,36}-dj111-wt23
+    py{35,36,37,38}-dj22-wt{27,28}
+    py{36,37,38}-dj30-wt28
 
 [testenv]
 install_command = pip install -e ".[test]" -U {opts} {packages}
 commands = py.test
+basepython =
+    py35: python3.5
+    py36: python3.6
+    py37: python3.7
+    py38: python3.8
 deps =
-  django111: django>=1.11,<1.12
-  django21: django>=2.1,<2.2
-  django22: django>=2.2,<2.3
-  wagtail23: wagtail>=2.3,<2.4
-  wagtail26: wagtail>=2.6,<2.7
+    dj111: django>=1.11,<1.12
+    dj22: django>=2.2,<2.3
+    dj30: django>=3.0,<3.1
+    wt23: wagtail>=2.3,<2.4
+    wt27: wagtail>=2.7,<2.8
+    wt28: wagtail>=2.8,<2.9
 
 [testenv:flake8]
 basepython = python3.6

--- a/wagtailautocomplete/tests/settings.py
+++ b/wagtailautocomplete/tests/settings.py
@@ -1,5 +1,3 @@
-from wagtail import VERSION
-
 SECRET_KEY = 'NOTSECRET'
 
 DATABASES = {
@@ -13,6 +11,12 @@ INSTALLED_APPS = (
     'django.contrib.contenttypes',
     'django.contrib.sessions',
     'django.contrib.staticfiles',
+    'wagtail.core',
+    'wagtail.documents',
+    'wagtail.images',
+    'wagtail.admin',
+    'wagtail.sites',
+    'wagtail.users',
     'taggit',
     'wagtailautocomplete',
     'wagtailautocomplete.tests.testapp',
@@ -21,6 +25,7 @@ INSTALLED_APPS = (
 MIDDLEWARE = (
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'wagtail.core.middleware.SiteMiddleware',
 )
 
 TEMPLATES = [
@@ -40,29 +45,3 @@ ROOT_URLCONF = 'wagtailautocomplete.tests.testapp.urls'
 
 STATIC_URL = '/static/'
 MEDIA_URL = '/media/'
-# Wagtail version-specific settings added below
-
-if VERSION >= (2, 0):
-    INSTALLED_APPS += (
-        'wagtail.core',
-        'wagtail.documents',
-        'wagtail.images',
-        'wagtail.admin',
-        'wagtail.sites',
-        'wagtail.users',
-    )
-    MIDDLEWARE += (
-        'wagtail.core.middleware.SiteMiddleware',
-    )
-else:
-    INSTALLED_APPS += (
-        'wagtail.wagtailcore',
-        'wagtail.wagtaildocs',
-        'wagtail.wagtailimages',
-        'wagtail.wagtailadmin',
-        'wagtail.wagtailsites',
-        'wagtail.wagtailusers',
-    )
-    MIDDLEWARE += (
-        'wagtail.wagtailcore.middleware.SiteMiddleware',
-    )

--- a/wagtailautocomplete/tests/test_autocompletepanel__page_to_page.py
+++ b/wagtailautocomplete/tests/test_autocompletepanel__page_to_page.py
@@ -3,14 +3,9 @@ from bs4 import BeautifulSoup
 from django.test import TestCase
 from django.contrib.auth import get_user_model
 
+from wagtail.core.models import Site
+
 from .testapp.models.page_to_page import SingleAutocompletePage
-
-from wagtail import VERSION
-
-if VERSION > (2, 0):
-    from wagtail.core.models import Site
-else:
-    from wagtail.wagtailcore.models import Site
 
 
 User = get_user_model()

--- a/wagtailautocomplete/tests/testapp/urls.py
+++ b/wagtailautocomplete/tests/testapp/urls.py
@@ -1,12 +1,7 @@
 from django.conf.urls import include, url
-from wagtail import VERSION
 
-if VERSION > (2, 0):
-    from wagtail.admin import urls as wagtailadmin_urls
-    from wagtail.core import urls as wagtail_urls
-else:
-    from wagtail.wagtailadmin import urls as wagtailadmin_urls
-    from wagtail.wagtailcore import urls as wagtail_urls
+from wagtail.admin import urls as wagtailadmin_urls
+from wagtail.core import urls as wagtail_urls
 
 from wagtailautocomplete.urls.admin import urlpatterns as autocomplete_admin_urls
 from wagtailautocomplete.urls.public import urlpatterns as autocomplete_public_urls


### PR DESCRIPTION
This mainly updates tested Wagtail and Django versions to consider only LTS and last releases. The `tox.ini` structure and the split to `setup.cfg` is based on what is done in Wagtail. Lastly, according to the tested versions of Wagtail, this specifies that the minimum required version is 2.3.

Note that tests fail with Django 3.0 as reported by #63.