### PR TITLE
FIX: Wagtail function moved require_admin_access

### DIFF
--- a/wagtailautocomplete/urls/admin.py
+++ b/wagtailautocomplete/urls/admin.py
@@ -1,5 +1,5 @@
 from django.conf.urls import url
-from wagtail.admin.decorators import require_admin_access
+from wagtail.admin.auth import require_admin_access
 
 from wagtailautocomplete.views import create, objects, search
 

--- a/wagtailautocomplete/urls/admin.py
+++ b/wagtailautocomplete/urls/admin.py
@@ -1,5 +1,8 @@
 from django.conf.urls import url
-from wagtail.admin.auth import require_admin_access
+try:
+    from wagtail.admin.auth import require_admin_access
+except ModuleNotFoundError:
+    from wagtail.admin.decorators import require_admin_access
 
 from wagtailautocomplete.views import create, objects, search
 

--- a/wagtailautocomplete/urls/admin.py
+++ b/wagtailautocomplete/urls/admin.py
@@ -1,8 +1,8 @@
 from django.conf.urls import url
 try:
-    from wagtail.admin.auth import require_admin_access
-except ModuleNotFoundError:
     from wagtail.admin.decorators import require_admin_access
+except ImportError:
+    from wagtail.admin.auth import require_admin_access
 
 from wagtailautocomplete.views import create, objects, search
 

--- a/wagtailautocomplete/urls/admin.py
+++ b/wagtailautocomplete/urls/admin.py
@@ -6,7 +6,6 @@ except ModuleNotFoundError:
 
 from wagtailautocomplete.views import create, objects, search
 
-
 urlpatterns = [
     url(r'^create/', require_admin_access(create)),
     url(r'^objects/', require_admin_access(objects)),


### PR DESCRIPTION
Wagtail 2.8 require_admin_access has been moved from wagtail.admin.decorators to wagtail.admin.auth.
Additionally we could create a check on what version Wagtail is being used to import the right import accordingly.