### PR TITLE
Update tox config to test against current versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: ~/wagtail-autocomplete-repo
     docker:
-      - image: randomknowledge/docker-pyenv-tox
+      - image: randomknowledge/docker-pyenv-tox:maintenance_update-versions
     steps:
       - checkout
       - run:

--- a/setup.py
+++ b/setup.py
@@ -37,9 +37,7 @@ setup(
             'tox',
             'pytest>=3.5',
             'pytest-django>=3.2',
-            # FIXME: the maximum version is needed until
-            # https://github.com/wagtail/wagtail/pull/5817
-            'beautifulsoup4>=4.6.0,<4.6.1',
+            'beautifulsoup4>=4.8',
             'html5lib>=0.999999999',
             'pytest-pythonpath>=0.7.2',
         ],

--- a/tox.ini
+++ b/tox.ini
@@ -2,25 +2,23 @@
 skipsdist = True
 usedevelop = True
 envlist =
-    py{35,36}-dj111-wt23
-    py{35,36,37,38}-dj22-wt{27,28}
-    py{36,37,38}-dj30-wt28
+    py{36,37,38}-dj{22,30,31}-wt211
+    py{36,37,38,39}-dj{22,30,31}-wt212
 
 [testenv]
 install_command = pip install -e ".[test]" -U {opts} {packages}
 commands = py.test
 basepython =
-    py35: python3.5
     py36: python3.6
     py37: python3.7
     py38: python3.8
+    py39: python3.9
 deps =
-    dj111: django>=1.11,<1.12
     dj22: django>=2.2,<2.3
     dj30: django>=3.0,<3.1
-    wt23: wagtail>=2.3,<2.4
-    wt27: wagtail>=2.7,<2.8
-    wt28: wagtail>=2.8,<2.9
+    dj31: django>=3.1,<3.2
+    wt211: wagtail>=2.11,<2.12
+    wt212: wagtail>=2.12,<2.13
 
 [testenv:flake8]
 basepython = python3.6

--- a/wagtailautocomplete/tests/settings.py
+++ b/wagtailautocomplete/tests/settings.py
@@ -25,7 +25,6 @@ INSTALLED_APPS = (
 MIDDLEWARE = (
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'wagtail.core.middleware.SiteMiddleware',
 )
 
 TEMPLATES = [


### PR DESCRIPTION
* Remove max version requirement from beautifulsoup, now fixed
  in Wagtail
* Remove wagtail middleware from apps, since it doesn't exist in
  newer versions and isn't needed for tests