### PR TITLE
Fixed AutocompletePanel to work with wagtail 3.0, fixes #115

### DIFF
--- a/wagtailautocomplete/edit_handlers.py
+++ b/wagtailautocomplete/edit_handlers.py
@@ -43,6 +43,11 @@ class AutocompletePanel(FieldPanel):
             )
         }
 
+    def get_form_options(self):
+        opts = super().get_form_options()
+        opts['widgets'] = self.widget_overrides()
+        return opts
+
     @cached_property
     def target_model(self):
         if self._target_model:


### PR DESCRIPTION
For one of our projects, this fixes the issue that a select-input is shown instead of the autocomplete-widget.
This does not fix the tests, which also seem to be incompatible with the new wagtail release.