### PR TITLE
Wagtail 4 compatibility

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,7 +13,7 @@ Features
 ~~~~~~~~
 
 * Rapidly select related objects via a smooth autocomplete interface
-* A drop-in alternative to ``PageChooserPanel`` or ``SnippetChooserPanel``
+* A drop-in alternative to ``FieldPanel``
 * Create new objects from the autocomplete input if your search turns up blank
 * React component can be used outside of the Wagtail admin for public-facing forms
 * Default theme shares the color scheme and styles of the Wagtail admin

--- a/docs/basic_usage.rst
+++ b/docs/basic_usage.rst
@@ -21,13 +21,13 @@ We have a ``BlogPage`` that lets the editor select an ``AuthorPage`` page.
         )
 
 The ``AuthorPage`` would traditionally be selected with a
-:class:`~wagtail:wagtail.admin.panels.FieldPanel`,
+:class:`~wagtail:wagtail.admin.panels.PageChooserPanel`,
 like the following.
 
 .. code-block:: python
 
     content_panels = Page.content_panels + [
-        FieldPanel('author', page_type='app_label.AuthorPage'),
+        PageChooserPanel('author', page_type='app_label.AuthorPage'),
     ]
 
 Instead we can use :py:class:`AutocompletePanel`.
@@ -54,12 +54,12 @@ AutocompletePanel
     to a model class or a model string in ``app_label.ModelName`` syntax.
 
     .. note::
-        Unlike :class:`~wagtail:wagtail.admin.panels.FieldPanel`,
-        ``AutocompletePanel`` does not support receiving ``target_model`` as a list.
+        Unlike :class:`~wagtail:wagtail.admin.panels.PageChooserPanel`,
+        ``AutocompletePanel`` does not take a ``page_type`` argument but uses ``target_model`` argument, but it cannot be a list.
 
     .. note::
         ``AutocompletePanel`` does not support receiving the ``can_choose_root``
-        argument that :class:`~wagtail:wagtail.admin.panels.FieldPanel`
+        argument that :class:`~wagtail:wagtail.admin.panels.PageChooserPanel`
         does.
 
 Multiple Selection With Clusterable Models

--- a/docs/basic_usage.rst
+++ b/docs/basic_usage.rst
@@ -21,13 +21,13 @@ We have a ``BlogPage`` that lets the editor select an ``AuthorPage`` page.
         )
 
 The ``AuthorPage`` would traditionally be selected with a
-:class:`~wagtail:wagtail.wagtailadmin.edit_handlers.PageChooserPanel`,
+:class:`~wagtail:wagtail.admin.panels.FieldPanel`,
 like the following.
 
 .. code-block:: python
 
     content_panels = Page.content_panels + [
-        PageChooserPanel('author', page_type='app_label.AuthorPage'),
+        FieldPanel('author', page_type='app_label.AuthorPage'),
     ]
 
 Instead we can use :py:class:`AutocompletePanel`.
@@ -54,12 +54,12 @@ AutocompletePanel
     to a model class or a model string in ``app_label.ModelName`` syntax.
 
     .. note::
-        Unlike :class:`~wagtail:wagtail.wagtailadmin.edit_handlers.PageChooserPanel`,
+        Unlike :class:`~wagtail:wagtail.admin.panels.FieldPanel`,
         ``AutocompletePanel`` does not support receiving ``target_model`` as a list.
 
     .. note::
         ``AutocompletePanel`` does not support receiving the ``can_choose_root``
-        argument that :class:`~wagtail:wagtail.wagtailadmin.edit_handlers.PageChooserPanel`
+        argument that :class:`~wagtail:wagtail.admin.panels.FieldPanel`
         does.
 
 Multiple Selection With Clusterable Models
@@ -76,7 +76,7 @@ provide a multiple selection widget. For example:
 .. code-block:: python
 
     from django.db import models
-    from wagtail.core.models import Page
+    from wagtail.models import Page
     from modelcluster.models import ClusterableModel
     from modelcluster.fields import ParentalManyToManyField
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,11 @@
 Changelog
 =========
 
+Unreleased
+----------
+
+* Added Wagtail 4.x compatibility
+
 0.10 Release
 ------------
 

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -22,16 +22,16 @@ Add Wagtail Autocomplete's URL patterns to your project's URL config, usually in
 
     from django.conf.urls import include, url
 
-    from wagtail.wagtailcore import urls as wagtail_urls
+    from wagtail import urls as wagtail_urls
 
     from wagtailautocomplete.urls.admin import urlpatterns as autocomplete_admin_urls
 
     urlpatterns = [
         # ...
-        url(r'^admin/autocomplete/', include(autocomplete_admin_urls)),
-        url(r'^admin/', include(wagtailadmin_urls)),
+        path('admin/autocomplete/', include(autocomplete_admin_urls)),
+        path("admin/", include(wagtailadmin_urls)),
         # ...
-        url(r'', include(wagtail_urls)),
+        path("", include(wagtail_urls)),
     ]
 
 This makes available custom API endpoints that provide the search and creation behavior for the widget.

--- a/docs/using_other_models.rst
+++ b/docs/using_other_models.rst
@@ -11,17 +11,16 @@ Selecting Snippets
 
 For example, we have a Django model ``Link`` that we have registered as a snippet.
 We also have a ``BlogPage`` model that would traditionally use a
-:class:`~wagtail:wagtail.wagtailsnippets.edit_handlers.SnippetChooserPanel`
+:class:`~wagtail:wagtail.admin.panels.FieldPanel`
 
 
 .. code-block:: python
 
     from django.db import models
 
-    from wagtail.wagtailadmin.edit_handlers import FieldPanel
-    from wagtail.wagtailcore.models import Page
-    from wagtail.wagtailsnippets.edit_handlers import SnippetChooserPanel
-    from wagtail.wagtailsnippets.models import register_snippet
+    from wagtail.admin.panels import FieldPanel
+    from wagtail.models import Page
+    from wagtail.snippets.models import register_snippet
 
     @register_snippet
     class Link(models.Model):
@@ -43,11 +42,11 @@ We also have a ``BlogPage`` model that would traditionally use a
         )
 
         content_panels = [
-            SnippetChooserPanel('external_link'),
+            FieldPanel('external_link'),
         ]
 
 We can replace the
-:class:`~wagtail:wagtail.wagtailsnippets.edit_handlers.SnippetChooserPanel`
+:class:`~wagtail:wagtail.admin.panels.FieldPanel`
 usage with
 :class:`AutocompletePanel`.
 

--- a/tox.ini
+++ b/tox.ini
@@ -2,9 +2,9 @@
 skipsdist = True
 usedevelop = True
 envlist =
-    py{37,38,39,310}-dj{32}-wt{215}
-    py{37,38,39,310}-dj{32,40}-wt{216,30,40}
-    py{37,38,39,310}-dj{41}-wt{40}
+    py{37,38,39}-dj{32}-wt{215}
+    py{37,38,39}-dj{32,40}-wt{216,30,40}
+    py{37,38,39}-dj{41}-wt{40}
 
 [testenv]
 install_command = pip install -e ".[test]" -U {opts} {packages}
@@ -13,7 +13,6 @@ basepython =
     py37: python3.7
     py38: python3.8
     py39: python3.9
-    py310: python3.10
 deps =
     dj32: django>=3.2,<4.0
     wt215: wagtail>=2.15,<2.16

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,9 @@
 skipsdist = True
 usedevelop = True
 envlist =
-    py{37,38,39}-dj{30,31,32}-wt{215}
-    py{37,38,39}-dj{32,40}-wt{216,30}
+    py{37,38,39,310}-dj{32}-wt{215}
+    py{37,38,39,310}-dj{32,40}-wt{216,30,40}
+    py{37,38,39,310}-dj{41}-wt{40}
 
 [testenv]
 install_command = pip install -e ".[test]" -U {opts} {packages}
@@ -12,13 +13,13 @@ basepython =
     py37: python3.7
     py38: python3.8
     py39: python3.9
+    py310: python3.10
 deps =
-    dj30: django>=3.0,<3.1
-    dj31: django>=3.1,<3.2
     dj32: django>=3.2,<4.0
     wt215: wagtail>=2.15,<2.16
     wt216: wagtail>=2.16,<3.0
     wt30: wagtail>=3.0,<4.0
+    wt40: wagtail>=4.0,<5.0
 [testenv:flake8]
 basepython = python3.7
 deps = flake8>3.7

--- a/tox.ini
+++ b/tox.ini
@@ -2,9 +2,9 @@
 skipsdist = True
 usedevelop = True
 envlist =
-    py{37,38,39}-dj{32}-wt{215}
-    py{37,38,39}-dj{32,40}-wt{216,30,40}
-    py{37,38,39}-dj{41}-wt{40}
+    py{37,38,39,310}-dj{32}-wt{215,216}
+    py{38,39,310}-dj{32,40}-wt{216,30,40}
+    py{38,39,310,311}-dj{41}-wt{40}
 
 [testenv]
 install_command = pip install -e ".[test]" -U {opts} {packages}
@@ -13,12 +13,16 @@ basepython =
     py37: python3.7
     py38: python3.8
     py39: python3.9
+    py310: python3.10
+    py311: python3.11
 deps =
     dj32: django>=3.2,<4.0
+    dj40: django>=4.0,<4.1
+    dj41: django>=4.1,<4.2
     wt215: wagtail>=2.15,<2.16
     wt216: wagtail>=2.16,<3.0
     wt30: wagtail>=3.0,<4.0
-    wt40: wagtail>=4.0,<5.0
+    wt40: wagtail>=4.0,<4.1
 [testenv:flake8]
 basepython = python3.7
 deps = flake8>3.7

--- a/tox.ini
+++ b/tox.ini
@@ -13,8 +13,8 @@ basepython =
     py37: python3.7
     py38: python3.8
     py39: python3.9
-    py310: python3.10
-    py311: python3.11
+    py310: "python3.10"
+    py311: "python3.11"
 deps =
     dj32: django>=3.2,<4.0
     dj40: django>=4.0,<4.1

--- a/tox.ini
+++ b/tox.ini
@@ -2,9 +2,9 @@
 skipsdist = True
 usedevelop = True
 envlist =
-    py{37,38,39,310}-dj{32}-wt{215,216}
-    py{38,39,310}-dj{32,40}-wt{216,30,40}
-    py{38,39,310,311}-dj{41}-wt{40}
+    py{37,38,39}-dj{32}-wt{215,216}
+    py{38,39}-dj{32,40}-wt{216,30,40}
+    py{38,39}-dj{41}-wt{40}
 
 [testenv]
 install_command = pip install -e ".[test]" -U {opts} {packages}
@@ -13,8 +13,6 @@ basepython =
     py37: python3.7
     py38: python3.8
     py39: python3.9
-    py310: "python3.10"
-    py311: "python3.11"
 deps =
     dj32: django>=3.2,<4.0
     dj40: django>=4.0,<4.1

--- a/wagtailautocomplete/tests/test_edit_handlers.py
+++ b/wagtailautocomplete/tests/test_edit_handlers.py
@@ -65,13 +65,20 @@ class TestAutocompletePanel(TestCase):
         self.assertIn('wagtailautocomplete/dist.js', media_html)
 
     def test_render_js_init(self):
-        result = self.autocomplete_panel.render_as_field()
+        if WAGTAIL_VERSION >= (4, 0):
+            result = self.autocomplete_panel.render_html()
+        else:
+            result = self.autocomplete_panel.render_as_field()
 
         self.assertIn('initAutoCompleteWidget("id_owner");', result)
 
     def test_render_as_field(self):
-        result = self.autocomplete_panel.render_as_field()
-        self.assertIn('<p class="help">the owner</p>', result)
+        if WAGTAIL_VERSION >= (4, 0):
+            result = self.autocomplete_panel.render_html()
+            self.assertIn('<div class="help">the owner</div>', result)
+        else:
+            result = self.autocomplete_panel.render_as_field()
+            self.assertIn('<p class="help">the owner</p>', result)
 
         soup = BeautifulSoup(result, 'html5lib')
         elements = soup.find_all(attrs={'data-autocomplete-input': True})
@@ -102,9 +109,12 @@ class TestAutocompletePanel(TestCase):
             autocomplete_panel = self.base_autocomplete_panel.bind_to(
                 instance=test_instance, form=form, request=self.request
             )
-        result = autocomplete_panel.render_as_field()
-
-        self.assertIn('<p class="help">the owner</p>', result)
+        if WAGTAIL_VERSION >= (4, 0):
+            result = autocomplete_panel.render_html()
+            self.assertIn('<div class="help">the owner</div>', result)
+        else:
+            result = autocomplete_panel.render_as_field()
+            self.assertIn('<p class="help">the owner</p>', result)
 
         soup = BeautifulSoup(result, 'html5lib')
         element = soup.find(attrs={'data-autocomplete-input': True})
@@ -135,8 +145,14 @@ class TestAutocompletePanel(TestCase):
                 instance=self.test_house, form=form, request=self.request
             )
 
-        result = autocomplete_panel.render_as_field()
-        self.assertIn('Occupants', result)
+        if WAGTAIL_VERSION >= (4, 0):
+            result = autocomplete_panel.render_html()
+            # Wagtail 4 renders the label using Javascript,
+            # so we don't get a label in the HTML
+            self.assertIn('data-contentpath="occupants"', result)
+        else:
+            result = autocomplete_panel.render_as_field()
+            self.assertIn('Occupants', result)
 
         soup = BeautifulSoup(result, 'html5lib')
         element = soup.find(attrs={'data-autocomplete-input': True})
@@ -178,7 +194,11 @@ class TestAutocompletePanel(TestCase):
                 instance=self.house_occupant, form=form, request=self.request
             )
 
-        result = autocomplete_panel.render_as_field()
+        if WAGTAIL_VERSION >= (4, 0):
+            result = autocomplete_panel.render_html()
+        else:
+            result = autocomplete_panel.render_as_field()
+
         self.assertIn('Group', result)
 
         soup = BeautifulSoup(result, 'html5lib')
@@ -205,8 +225,14 @@ class TestAutocompletePanel(TestCase):
             autocomplete_panel = self.base_autocomplete_panel.bind_to(
                 instance=self.test_house, form=form, request=self.request
             )
-
-        self.assertIn('<span>This field is required.</span>', autocomplete_panel.render_as_field())
+        
+        if WAGTAIL_VERSION >= (4, 0):
+            result = autocomplete_panel.render_html()
+            soup = BeautifulSoup(result, 'html5lib')
+            self.assertIn('This field is required.', soup.find('p', class_='error-message').text)
+        else:
+            result = autocomplete_panel.render_as_field()
+            self.assertIn('<span>This field is required.</span>', result)
 
     def test_target_model(self):
         if WAGTAIL_VERSION >= (3, 0):

--- a/wagtailautocomplete/tests/test_edit_handlers.py
+++ b/wagtailautocomplete/tests/test_edit_handlers.py
@@ -225,7 +225,7 @@ class TestAutocompletePanel(TestCase):
             autocomplete_panel = self.base_autocomplete_panel.bind_to(
                 instance=self.test_house, form=form, request=self.request
             )
-        
+
         if WAGTAIL_VERSION >= (4, 0):
             result = autocomplete_panel.render_html()
             soup = BeautifulSoup(result, 'html5lib')


### PR DESCRIPTION
This fixes testing for Wagtail v4 and updates the documentation to be inline with Wagtail 3+

I didn't need to alter any of the core package files.