### PR TITLE
Support Setting A Model's Search Field Through A Setting

### DIFF
--- a/docs/customization.rst
+++ b/docs/customization.rst
@@ -27,6 +27,9 @@ You can enable this type of behavior by defining an ``autocomplete_create`` clas
 Custom Search Field
 ===================
 
+With A Model Method
+-------------------
+
 By default, the autocomplete widget will match input against the ``title`` field on your model. If you're using a model that doesn't have a ``title`` attribute, or you just want to search using a different field, you can customize which field it matches against by defining an ``autocomplete_search_field`` property on your model:
 
 .. code-block:: python
@@ -53,6 +56,35 @@ By default, the autocomplete widget will match input against the ``title`` field
 
     Additionally, this means that ``autocomplete_search_field`` *must* be a model field and cannot be an arbitrary property or method. There is also the possibility to define a custom filter function, described in `Custom QuerySet Filter Function`_.
 
+With A Setting
+--------------
+
+Alternatively, you may define the search field in a ``WAGTAILAUTOCOMPLETE_CUSTOM_SEARCH_FIELD`` setting:
+
+
+.. code-block:: python
+
+    # settings.py file
+    ...
+    WAGTAILAUTOCOMPLETE_CUSTOM_SEARCH_FIELD = {
+        "myapp.MyModel": "name",
+    }
+
+Or the search field may be a callable:
+
+.. code-block:: python
+
+    # settings.py file
+    ...
+    WAGTAILAUTOCOMPLETE_CUSTOM_SEARCH_FIELD = {
+        "myapp.MyModel": lambda my_model: f"{my_model.first_name} {my_model.last_name}",
+    }
+
+.. note::
+
+    If you define both an ``autocomplete_search_field`` method on your model and an entry for your model in the ``WAGTAILAUTOCOMPLETE_CUSTOM_SEARCH_FIELD`` setting, the method on your model will take precedence.
+
+
 Custom Label Display
 ====================
 
@@ -75,6 +107,9 @@ By default, the autocomplete widget will display the ``title`` field from a mode
 Custom QuerySet Filter Function
 ====================
 
+With A Model Method
+-------------------
+
 By default, the autocomplete widget uses an ``icontains`` lookup to search for matching items of the given model. To change that behavior a custom filter function can be defined, that will be called instead of the default filtering. The function needs to return a QuerySet of the expected model.
 
 .. code-block:: python
@@ -96,3 +131,32 @@ By default, the autocomplete widget uses an ``icontains`` lookup to search for m
             filter_kwargs = dict()
             filter_kwargs[field_name + '__contains'] = search_term
             return MyModel.objects.filter(**filter_kwargs)
+
+With A Setting
+--------------
+
+You may also define custom queryset filtering through a ``WAGTAILAUTOCOMPLETE_CUSTOM_FILTER_FIELDS`` setting:
+
+.. code-block:: python
+
+    # settings.py
+    ...
+    WAGTAILAUTOCOMPLETE_CUSTOM_FILTER_FIELDS = {
+        "myapp.MyModel": {"fields": ["first_name", "last_name"]},
+    }
+
+By default, the filtering will use an OR relation for the fields. If you prefer a different relation, you may define it by passing in a ``connector`` at the same level as ``fields``:
+
+.. code-block:: python
+
+    # settings.py
+    from django.db.models import Q
+    ...
+    WAGTAILAUTOCOMPLETE_CUSTOM_FILTER_FIELDS = {
+        "myapp.MyModel": {"fields": ["first_name", "last_name"], "connector": Q.AND},
+    }
+
+
+.. note::
+
+    If you define both an ``autocomplete_custom_queryset_filter`` method on your model and an entry for your model in the ``WAGTAILAUTOCOMPLETE_CUSTOM_FILTER_FIELDS`` setting, the method on your model will take precedence.

--- a/wagtailautocomplete/views.py
+++ b/wagtailautocomplete/views.py
@@ -2,9 +2,10 @@ from http import HTTPStatus
 from urllib.parse import unquote
 
 from django.apps import apps
+from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError
-from django.db.models import Model, QuerySet
+from django.db.models import Model, Q, QuerySet
 from django.http import (HttpResponseBadRequest, HttpResponseForbidden,
                          HttpResponseNotFound, JsonResponse)
 from django.views.decorators.http import require_GET, require_POST
@@ -14,8 +15,22 @@ def render_page(page):
     if getattr(page, 'specific', None):
         # For support of non-Page models like Snippets.
         page = page.specific
+    # Determine the title from either (in this order):
+    #  1. a page's autocomplete_label() method
+    #  2. an entry for the page in the WAGTAILAUTOCOMPLETE_CUSTOM_SEARCH_FIELD
+    #     setting
+    #  3. the page's title field
     if callable(getattr(page, 'autocomplete_label', None)):
         title = page.autocomplete_label()
+    elif (
+        hasattr(settings, "WAGTAILAUTOCOMPLETE_CUSTOM_SEARCH_FIELD") and
+        page._meta.label in settings.WAGTAILAUTOCOMPLETE_CUSTOM_SEARCH_FIELD
+    ):
+        title = settings.WAGTAILAUTOCOMPLETE_CUSTOM_SEARCH_FIELD[
+            page._meta.label
+        ]
+        if callable(title):
+            title = title(page)
     else:
         title = page.title
     return dict(pk=page.pk, title=title)
@@ -90,7 +105,8 @@ def filter_queryset(search_query: str, model: Model) -> QuerySet:
     """
     Filter db entries of the given model for the given search_query and
     returns it. The filter operates on either the default column title or the
-    custom column defined in autocomplete_search_field.
+    custom column defined in autocomplete_search_field or the sutom columns
+    defined in a setting.
 
     Args:
         search_query (str): Term to search for.
@@ -99,9 +115,31 @@ def filter_queryset(search_query: str, model: Model) -> QuerySet:
     Returns:
         QuerySet: QuerySet containing the search results.
     """
-    field_name = getattr(model, 'autocomplete_search_field', 'title')
+    # Determine the filter kwargs from either (in this order):
+    #  1. a page's autocomplete_search_field() method
+    #  2. an entry for the page in the WAGTAILAUTOCOMPLETE_CUSTOM_FILTER_FIELDS
+    #     setting
+    #  3. the page's title field
+    field_name = getattr(model, 'autocomplete_search_field', None)
     filter_kwargs = dict()
-    filter_kwargs[field_name + '__icontains'] = search_query
+    if field_name:
+        filter_kwargs[field_name + '__icontains'] = search_query
+    elif (
+        hasattr(settings, "WAGTAILAUTOCOMPLETE_CUSTOM_FILTER_FIELDS") and
+        model._meta.label in settings.WAGTAILAUTOCOMPLETE_CUSTOM_FILTER_FIELDS
+    ):
+        field_names = settings.WAGTAILAUTOCOMPLETE_CUSTOM_FILTER_FIELDS[
+            model._meta.label
+        ].get("fields", [])
+        for field_name in field_names:
+            filter_kwargs[field_name + '__icontains'] = search_query
+        connector = settings.WAGTAILAUTOCOMPLETE_CUSTOM_FILTER_FIELDS[
+            model._meta.label
+        ].get("connector", Q.OR)
+        return model.objects.filter(**filter_kwargs, _connector=connector)
+    else:
+        filter_kwargs['title__icontains'] = search_query
+
     return model.objects.filter(**filter_kwargs)
 
 


### PR DESCRIPTION
# Use Case:
The use case for this feature is a project using Django's default user model, with a `Page` that has a relation to the user model. Since Django's default user model does not have a `title` field, it's not possible to use `wagtail-autocomplete` on the relation. One option would be to define a custom user model and a `title` field, but doing so mid-project [a difficult task](https://docs.djangoproject.com/en/dev/topics/auth/customizing/#changing-to-a-custom-user-model-mid-project). Instead, it would be great to be able to point the search to a different field on the model without having to edit the model.

# Changes
This pull request:
 - updates the `views.render_page()` function to check (only if the page doesn't have an `autocomplete_label` attribute) for a `WAGTAILAUTOCOMPLETE_CUSTOM_SEARCH_FIELD` setting, and (if the setting is defined) to use the value of that setting.
 - updates the `views.filter_queryset()` function to check (only if the page doesn't have an `autocomplete_search_field` attribute) for a `WAGTAILAUTOCOMPLETE_CUSTOM_FILTER_FIELDS` setting, and (if the setting is defined) to use the value of that setting.
 - updates the documentation based on these changes

As a result, it is now possible to define which field(s) to use in the search without having to edit the model.