### PR TITLE
Wagtail Latest Version Compatibility Testing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,25 +1,5 @@
 version: 2
 jobs:
-  test_py38:
-    working_directory: ~/wagtail-autocomplete-repo
-    docker:
-      - image: cimg/python:3.8
-    steps:
-      - checkout
-      - run:
-          name: install dependencies
-          command: |
-            python -m venv venv
-            . venv/bin/activate
-            pip install -U pip
-            pip install ".[test]"
-      - run:
-          name: tests
-          command: venv/bin/tox -f py38
-      - run:
-          name: flake8
-          command: venv/bin/tox -e flake8
-
   test_py39:
     working_directory: ~/wagtail-autocomplete-repo
     docker:
@@ -80,11 +60,31 @@ jobs:
           name: flake8
           command: venv/bin/tox -e flake8
 
+  test_py312:
+    working_directory: ~/wagtail-autocomplete-repo
+    docker:
+      - image: cimg/python:3.12
+    steps:
+      - checkout
+      - run:
+          name: install dependencies
+          command: |
+            python -m venv venv
+            . venv/bin/activate
+            pip install -U pip
+            pip install ".[test]"
+      - run:
+          name: tests
+          command: venv/bin/tox -f py312
+      - run:
+          name: flake8
+          command: venv/bin/tox -e flake8
+
 workflows:
   version: 2
   build:
     jobs:
-      - test_py38
       - test_py39
       - test_py310
       - test_py311
+      - test_py312

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,10 @@
 skipsdist = True
 usedevelop = True
 envlist =
-    py{39,310,311}-dj{32,40,41}-wt-{41,42,50,51,52}
-    py{312}-dj{42,50,51}-wt-{52,60,61,62,63}
+    py39-dj{32,40,41}-wt{41,42}
+    py39-dj{42}-wt{50,51,52}
+    py{310,311,312}-dj{42,50}-wt{60,61,62}
+    py{310,311,312}-dj{51}-wt{63}
 
 [testenv]
 install_command = pip install -e ".[test]" -U {opts} {packages}

--- a/tox.ini
+++ b/tox.ini
@@ -2,33 +2,38 @@
 skipsdist = True
 usedevelop = True
 envlist =
-    py{38,39,310}-dj{32,41}-wt{41,51,52}
-    py311-dj41-wt{41,51,52}
-    py311-dj42-wt{51,52}
+    py{39,310,311}-dj{32,40,41}-wt-{41,42,50,51,52}
+    py{312}-dj{42,50,51}-wt-{52,60,61,62,63}
 
 [testenv]
 install_command = pip install -e ".[test]" -U {opts} {packages}
 commands = py.test
 basepython =
-    py38: python3.8
     py39: python3.9
     py310: python3.10
     py311: python3.11
+    py312: python3.12
 deps =
     dj32: django>=3.2,<4.0
     dj41: django>=4.1,<4.2
     dj42: django>=4.2,<4.3
+    dj50: django>=5.0,<5.1
+    dj51: django>=5.1,<5.2
     wt41: wagtail>=4.1,<4.2
     wt42: wagtail>=4.2,<5.0
     wt50: wagtail>=5.0,<5.1
     wt51: wagtail>=5.1,<5.2
     wt52: wagtail>=5.2,<5.3
+    wt60: wagtail>=6.0,<6.1
+    wt61: wagtail>=6.1,<6.2
+    wt62: wagtail>=6.2,<6.3
+    wt63: wagtail>=6.3,<6.4
 
 [testenv:flake8]
 basepython =
-    py38: python3.8
     py39: python3.9
     py310: python3.10
     py311: python3.11
-deps = flake8>3.7
+    py312: python3.12
+deps = flake8>3.9
 commands = flake8 wagtailautocomplete


### PR DESCRIPTION
This pull request updates the CircleCI configuration and `tox.ini` file to support newer versions of Python, Django, and Wagtail. The most important changes include updating the Python versions used in the CI jobs and modifying the `tox` environments to include the latest versions of Django and Wagtail.

### CircleCI configuration updates:

* Modified the workflows to include the new `test_py312` job and remove the `test_py38` job.

### `tox.ini` updates:

* Wagtail testing now includes Wagtail (4.1, 4.2, 5.0, 5.1, 5.2, 6.0, 6.1, 6.2, 6.3).
* Added Python 3.12, Django 5.0, and Django 5.1 to the `basepython` and `deps` sections.
* Updated the `flake8` dependencies to support the newer Python versions.