### PR TITLE
Add request parameter to autocomplete_custom_queryset_filter function

### DIFF
--- a/docs/customization.rst
+++ b/docs/customization.rst
@@ -89,9 +89,9 @@ By default, the autocomplete widget uses an ``icontains`` lookup to search for m
 
         def autocomplete_label(self):
             return self.my_special_field
-        
+
         @staticmethod
-        def autocomplete_custom_queryset_filter(search_term: str) -> QuerySet:
+        def autocomplete_custom_queryset_filter(request, search_term: str) -> QuerySet:
             field_name='my_special_field'
             filter_kwargs = dict()
             filter_kwargs[field_name + '__contains'] = search_term

--- a/wagtailautocomplete/views.py
+++ b/wagtailautocomplete/views.py
@@ -67,7 +67,7 @@ def search(request):
         return HttpResponseBadRequest()
 
     if callable(getattr(model, 'autocomplete_custom_queryset_filter', None)):
-        queryset = model.autocomplete_custom_queryset_filter(search_query)
+        queryset = model.autocomplete_custom_queryset_filter(request, search_query)
         validate_queryset(queryset, model)
     else:
         queryset = filter_queryset(search_query, model)


### PR DESCRIPTION
This PR adds `request` to `autocomplete_custom_queryset_filter` function. This allows for more advanced filtering of search results (for ex. by user or his permissions).

My case scenario:
```
@staticmethod
    def autocomplete_custom_queryset_filter(request, search_term: str) -> QuerySet:
        return Client.objects.filter(created_by=request.user)
```