### PR TITLE
Add front-end tests to GHA

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,3 +50,20 @@ jobs:
           pip install ".[test]"
       - name: flake8
         run: tox -e flake8
+
+  js-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "26"
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - name: Lint CSS
+        run: npm run lint:css
+      - name: Lint JS
+        run: npm run lint:js
+      - name: Run tests
+        run: npm test


### PR DESCRIPTION
This adds a GitHub Actions job to our test workflow to run the front-end tests. 

Back-end tests and linting were migrated to GHA in #263.