### PR TITLE
Rebuild front-end assets when dependabot updates a dependency

### DIFF
--- a/.github/workflows/rebuild-assets.yml
+++ b/.github/workflows/rebuild-assets.yml
@@ -1,0 +1,33 @@
+# If Dependabot pushes updates to front-end dependencies, rebuild and
+# recommit the front-end assets.
+name: Rebuild front-end assets
+
+on:
+  pull_request:
+    # Ensure only changes to the front-end files trigger this workflow
+    paths:
+      - 'package.json'
+      - 'package-lock.json'
+      - 'client/**'
+      - 'webpack.config.js'
+
+permissions:
+  contents: write
+
+jobs:
+  rebuild-assets:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.head_ref }}
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: .nvmrc
+      - run: npm ci
+      - run: npm run build
+      - uses: stefanzweifel/git-auto-commit-action@4a55954c782fc1ea30b9056cd3e7a2b40ca8887d # v7.2.0
+        with:
+          commit_message: 'build: rebuild front-end assets'
+          file_pattern: 'wagtailautocomplete/static/wagtailautocomplete/*'


### PR DESCRIPTION
We commit built front-end assets in wagtail-autocomplete for ease of Python packaging. This creates an issue where Dependabot bumping a front-end dependency can mean that built assets are out-of-sync with the `package.json` on the same commit. 

One approach would be to invoke `npm run build` (which [Wagtail does](https://github.com/wagtail/wagtail/blob/v7.4.2/setup.py#L7-L23)) in the Python build, but this means the Python build system would depend on *also* having an entire Node build system available.

I believe it's simpler for this repo to simply automatically build and commit the assets when Dependabot makes an update, and deal with any build failures in the Dependabot PR. I believe this workflow should handle that.

It uses https://github.com/stefanzweifel/git-auto-commit-action, a third-party action, that will commit-back any changed files.

I'm not sure how to suggest we test this workflow, outside of waiting for a dependabot update and ensuring that this workflow runs then.
