### PR TITLE
Add tox -e interactive to run interactively

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ node_modules
 /build/
 /dist/
 wagtail_autocomplete.egg-info
+wagtailautocomplete.sqlite

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -83,4 +83,12 @@ To run the test suite against all dependency permutations, ensure that you have 
 
     tox
 
+To run the test app interactively, run:
+
+.. code-block:: sh
+
+    tox -e interactive
+
+Now you can visit http://localhost:8000/admin/ in a browser and log in with ``admin`` / ``changeme``.
+
 If you make changes to test models, you must regenerate the migrations in ``wagtailautocomplete/tests/testapp/migrations/``. This can be a sort of tricky process and is left as an excercise to the reader until I'm able to standardize a mechanism for doing so. Since test models are ephemeral it is OK, and even preferable, to regenerate migrations from scratch for each change.

--- a/testmanage.py
+++ b/testmanage.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python
+
+import argparse
+import os
+import shutil
+import sys
+import warnings
+
+from django.core.management import execute_from_command_line
+
+
+os.environ["DJANGO_SETTINGS_MODULE"] = "wagtailautocomplete.tests.settings"
+
+
+def make_parser():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--deprecation",
+        choices=["all", "pending", "imminent", "none"],
+        default="imminent",
+    )
+    return parser
+
+
+def parse_args(args=None):
+    return make_parser().parse_known_args(args)
+
+
+def runtests():
+    args, rest = parse_args()
+
+    only_wagtail = r"^wagtail(\.|$)"
+    if args.deprecation == "all":
+        # Show all deprecation warnings from all packages
+        warnings.simplefilter("default", DeprecationWarning)
+        warnings.simplefilter("default", PendingDeprecationWarning)
+    elif args.deprecation == "pending":
+        # Show all deprecation warnings from wagtail
+        warnings.filterwarnings(
+            "default", category=DeprecationWarning, module=only_wagtail
+        )
+        warnings.filterwarnings(
+            "default", category=PendingDeprecationWarning, module=only_wagtail
+        )
+    elif args.deprecation == "imminent":
+        # Show only imminent deprecation warnings from wagtail
+        warnings.filterwarnings(
+            "default", category=DeprecationWarning, module=only_wagtail
+        )
+    elif args.deprecation == "none":
+        # Deprecation warnings are ignored by default
+        pass
+
+    argv = [sys.argv[0]] + rest
+
+    try:
+        execute_from_command_line(argv)
+    finally:
+        from wagtail.test.settings import MEDIA_ROOT, STATIC_ROOT
+
+        shutil.rmtree(STATIC_ROOT, ignore_errors=True)
+        shutil.rmtree(MEDIA_ROOT, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    runtests()

--- a/tox.ini
+++ b/tox.ini
@@ -35,3 +35,22 @@ basepython =
     py314: python3.14
 deps = flake8>3.9
 commands = flake8 wagtailautocomplete
+
+[testenv:interactive]
+basepython = python3.14
+deps =
+    wagtail>=7.0,<7.5
+    Django>=6.1,<6.2
+
+commands_pre =
+    python {toxinidir}/testmanage.py makemigrations
+    python {toxinidir}/testmanage.py migrate
+    python {toxinidir}/testmanage.py shell -c "from django.contrib.auth.models import User;(not User.objects.filter(username='admin').exists()) and User.objects.create_superuser('admin', 'super@example.com', 'changeme')"
+    python {toxinidir}/testmanage.py createcachetable
+    python {toxinidir}/testmanage.py loaddata testdata
+
+commands =
+    {posargs:python testmanage.py runserver 0.0.0.0:8000}
+
+setenv =
+    INTERACTIVE = 1

--- a/wagtailautocomplete/tests/settings.py
+++ b/wagtailautocomplete/tests/settings.py
@@ -1,47 +1,61 @@
-SECRET_KEY = 'NOTSECRET'
+SECRET_KEY = "NOTSECRET"
+
+DEBUG = True
+
+ALLOWED_HOSTS = ["*"]
 
 DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': 'wagtailautocomplete',
+    "default": {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": "wagtailautocomplete.sqlite",
     }
 }
 
 INSTALLED_APPS = (
-    'django.contrib.auth',
-    'django.contrib.contenttypes',
-    'django.contrib.sessions',
-    'django.contrib.staticfiles',
-    'wagtail',
-    'wagtail.documents',
-    'wagtail.images',
-    'wagtail.admin',
-    'wagtail.sites',
-    'wagtail.users',
-    'taggit',
-    'wagtailautocomplete',
-    'wagtailautocomplete.tests.testapp',
+    "django.contrib.auth",
+    "django.contrib.contenttypes",
+    "django.contrib.messages",
+    "django.contrib.sessions",
+    "django.contrib.staticfiles",
+    "wagtail",
+    "wagtail.documents",
+    "wagtail.images",
+    "wagtail.admin",
+    "wagtail.sites",
+    "wagtail.users",
+    "taggit",
+    "wagtailautocomplete",
+    "wagtailautocomplete.tests.testapp",
+    "wagtail.snippets",
 )
 
 MIDDLEWARE = (
-    'django.contrib.sessions.middleware.SessionMiddleware',
-    'django.contrib.auth.middleware.AuthenticationMiddleware',
+    "django.contrib.sessions.middleware.SessionMiddleware",
+    "django.contrib.auth.middleware.AuthenticationMiddleware",
+    "django.middleware.csrf.CsrfViewMiddleware",
+    "django.contrib.messages.middleware.MessageMiddleware",
+    "django.middleware.clickjacking.XFrameOptionsMiddleware",
 )
 
 TEMPLATES = [
     {
-        'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': [],
-        'APP_DIRS': True,
-        'OPTIONS': {
-            'context_processors': [
-                'django.template.context_processors.request',
+        "BACKEND": "django.template.backends.django.DjangoTemplates",
+        "DIRS": [],
+        "APP_DIRS": True,
+        "OPTIONS": {
+            "context_processors": [
+                "django.template.context_processors.request",
+                "django.contrib.messages.context_processors.messages",
             ],
         },
     },
 ]
 
-ROOT_URLCONF = 'wagtailautocomplete.tests.testapp.urls'
+ROOT_URLCONF = "wagtailautocomplete.tests.testapp.urls"
 
-STATIC_URL = '/static/'
-MEDIA_URL = '/media/'
+STATIC_URL = "/static/"
+MEDIA_URL = "/media/"
+
+WAGTAIL_SITE_NAME = "wagtail-autocomplete test site"
+
+WAGTAILADMIN_BASE_URL = "http://localhost:8020"

--- a/wagtailautocomplete/tests/testapp/apps.py
+++ b/wagtailautocomplete/tests/testapp/apps.py
@@ -1,0 +1,7 @@
+from django.apps import AppConfig
+
+
+class WagtailAutocompleteTestAppConfig(AppConfig):
+    name = "wagtailautocomplete.tests.testapp"
+    verbose_name = "wagtail-autocomplete test app"
+    default_auto_field = "django.db.models.AutoField"

--- a/wagtailautocomplete/tests/testapp/fixtures/testdata.json
+++ b/wagtailautocomplete/tests/testapp/fixtures/testdata.json
@@ -1,0 +1,22 @@
+[
+  {
+    "model": "testapp.person",
+    "pk": 1,
+    "fields": {"name": "First Person", "group": null}
+  },
+  {
+    "model": "testapp.person",
+    "pk": 2,
+    "fields": {"name": "Second Person", "group": null}
+  },
+  {
+    "model": "testapp.person",
+    "pk": 3,
+    "fields": {"name": "Third Person", "group": null}
+  },
+  {
+    "model": "testapp.house",
+    "pk": 1,
+    "fields": {"name": "View Point House", "owner": 1, "occupants": [1, 2]}
+  }
+]

--- a/wagtailautocomplete/tests/testapp/wagtail_hooks.py
+++ b/wagtailautocomplete/tests/testapp/wagtail_hooks.py
@@ -1,0 +1,45 @@
+from wagtail.admin.panels import FieldPanel, InlinePanel
+from wagtail.snippets.models import register_snippet
+from wagtail.snippets.views.snippets import SnippetViewSet
+
+from wagtailautocomplete.edit_handlers import AutocompletePanel
+from wagtailautocomplete.tests.testapp.models import Group, House, Person
+
+
+class PersonViewSet(SnippetViewSet):
+    model = Person
+    icon = "user"
+    menu_label = "People"
+    list_display = ["name", "group"]
+    panels = [
+        FieldPanel("name"),
+        AutocompletePanel("group"),
+    ]
+
+
+class HouseViewSet(SnippetViewSet):
+    model = House
+    icon = "home"
+    menu_label = "Houses"
+    list_display = ["name", "owner"]
+    panels = [
+        FieldPanel("name"),
+        AutocompletePanel("owner"),
+        AutocompletePanel("occupants"),
+    ]
+
+
+class GroupViewSet(SnippetViewSet):
+    model = Group
+    icon = "group"
+    menu_label = "Groups"
+    list_display = ["title"]
+    panels = [
+        FieldPanel("title"),
+        InlinePanel("members", label="Member", panels=[FieldPanel("name")]),
+    ]
+
+
+register_snippet(PersonViewSet)
+register_snippet(HouseViewSet)
+register_snippet(GroupViewSet)


### PR DESCRIPTION
This adds a Wagtail conventional `interactive` env to tox (examples [1](https://github.com/torchbox/wagtail-grapple/blob/main/tox.ini#L66-L84), [2](https://github.com/wagtail/wagtail-localize/blob/main/tox.ini#L75-L103), [3](https://github.com/cfpb/wagtail-inventory/blob/main/tox.ini#L47-L64)), letting you run and open the app in a web browser, browse to snippets, and test out the functionality.

To do this it adds minimal boilerplate to the `wagtailautocomplete.tests.testapp` to add the test models as snippets so they're exposed in the admin, and adds the requisite settings to make the testapp runnable as a Wagtail site.

To try it out, run:

```
tox -e interactive
```

Then visit http://localhost:8000/admin/, `admin`/`changeme`, and then navigate to snippets and use `House` to test autocomplete functionality.